### PR TITLE
add views to basset path

### DIFF
--- a/src/AutomaticServiceProvider.php
+++ b/src/AutomaticServiceProvider.php
@@ -1,6 +1,7 @@
 <?php
 
 namespace Backpack\TinyMCEField;
+use Backpack\Basset\Facades\Basset;
 
 use Backpack\CRUD\ViewNamespaces;
 
@@ -82,6 +83,8 @@ trait AutomaticServiceProvider
         if ($this->app->runningInConsole()) {
             $this->bootForConsole();
         }
+
+        Basset::addViewPath($this->packageViewsPath());
     }
 
     /**


### PR DESCRIPTION
fixes: #5 

The view paths were not added to basset, so `basset:cache` wouldn't internalize those files until they were used. 
